### PR TITLE
Allow Date parts to not be integers

### DIFF
--- a/citeproc/source/__init__.py
+++ b/citeproc/source/__init__.py
@@ -95,7 +95,11 @@ class Date(DateBase):
         if 'day' in args and 'month' not in args:
             raise TypeError('When specifying the day, you should also specify '
                             'the month')
-        args = {key: int(value) for key, value in args.items()}
+        for key, value in args.items():
+            try:
+                args[key] = int(value)
+            except ValueError:
+                pass
         super(Date, self).__init__(args, required, optional)
 
     def sort_key(self):

--- a/tests/failing_tests.txt
+++ b/tests/failing_tests.txt
@@ -114,8 +114,8 @@ disambiguate_ByCiteGivennameExpandCrossNestedNames
 disambiguate_ByCiteGivennameNoShortFormInitializeWith
 disambiguate_ByCiteGivennameShortFormInitializeWith
 disambiguate_ByCiteGivennameShortFormNoInitializeWith
-disambiguate_ByCiteIncremental1                                    # uncaught exception
-disambiguate_ByCiteIncremental2                                    # uncaught exception
+disambiguate_ByCiteIncremental1
+disambiguate_ByCiteIncremental2
 disambiguate_ByCiteMinimalGivennameExpandMinimalNames
 disambiguate_ByCiteRetainNamesOnFailureIfYearSuffixNotAvailable
 disambiguate_CitationLabelDefault


### PR DESCRIPTION
Fixes two uncaught exceptions in the test suite

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/brechtm/citeproc-py/44)
<!-- Reviewable:end -->
