### PR TITLE
Fix locator conditions (resolve #142)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,5 @@ recursive-include citeproc/data/schema *.rnc *.md *.rng
 recursive-include docs *.html *.css *.png
 recursive-include examples *.py *.csl *.bib
 recursive-include tests *.py *.bib
+recursive-include tests/local *.txt
 prune tests/citeproc-test

--- a/citeproc/model.py
+++ b/citeproc/model.py
@@ -1470,7 +1470,7 @@ class If(CitationStylesElement, Parent):
         return result
 
     def _locator(self, item):
-        return [var.replace('-', ' ') == item.locator.label
+        return [item.has_locator and var.replace('-', ' ') == item.locator.label
                 for var in self.get('locator').split()]
 
     def _position(self, item, context):

--- a/tests/citeproc-test.py
+++ b/tests/citeproc-test.py
@@ -22,6 +22,7 @@ CITEPROC_TEST_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__),
                                      'test-suite'))
 TEST_PARSER_PATH = os.path.join(CITEPROC_TEST_PATH, 'processor.py')
 TESTS_PATH = os.path.join(CITEPROC_TEST_PATH, 'processor-tests', 'humans')
+LOCAL_TESTS_PATH = os.path.join(os.path.dirname(__file__), "local")
 
 FAILING_TESTS_FILE = 'failing_tests.txt'
 
@@ -306,8 +307,9 @@ if __name__ == '__main__':
     failed_tests = FailedTests(os.path.join(os.path.dirname(__file__),
                                             FAILING_TESTS_FILE))
     count = 0
-    test_files = os.path.join(TESTS_PATH, '{}.txt'.format(glob_pattern))
-    for filename in sorted(glob.glob(test_files)):
+    test_files = list(glob.glob(os.path.join(TESTS_PATH, '{}.txt'.format(glob_pattern))))
+    test_files += list(glob.glob(os.path.join(LOCAL_TESTS_PATH, '{}.txt'.format(glob_pattern))))
+    for filename in sorted(test_files):
         test_name, _ = os.path.basename(filename).split('.txt')
         category, _ = os.path.basename(filename).split('_')
         passed_count.setdefault(category, 0)

--- a/tests/local/condition_LocatorVariables.txt
+++ b/tests/local/condition_LocatorVariables.txt
@@ -1,0 +1,108 @@
+>>===== MODE =====>>
+citation
+<<===== MODE =====<<
+
+
+>>===== DESCRIPTION =====>>
+<https://github.com/citeproc-py/citeproc-py/issues/142>
+<<===== DESCRIPTION =====<<
+
+
+>>===== RESULT =====>>
+(Doe)
+(Doe 23)
+<<===== RESULT =====<<
+
+
+>>===== CITATION-ITEMS =====>>
+[
+    [
+        {
+            "id": "ITEM-1"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "label": "page",
+            "locator": 23
+        }
+    ]
+]
+<<===== CITATION-ITEMS =====<<
+
+
+>>===== CSL =====>>
+<style
+      xmlns="http://purl.org/net/xbiblio/csl"
+      class="note"
+      version="1.0">
+  <info>
+    <id />
+    <title />
+    <updated>2024-07-26T21:37:09+08:00</updated>
+  </info>
+  <macro name="author-short">
+    <group delimiter=", ">
+      <names variable="author">
+        <name form="short" initialize-with=". " and="text"/>
+        <substitute>
+          <names variable="editor"/>
+          <names variable="translator"/>
+          <text variable="title" form="short"/>
+        </substitute>
+      </names>
+    </group>
+  </macro>
+  <citation>
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <choose>
+        <if locator="page line" match="any">
+          <group delimiter=" ">
+            <text macro="author-short"/>
+            <text variable="locator"/>
+          </group>
+        </if>
+        <else>
+          <group delimiter=", ">
+            <text macro="author-short"/>
+            <group>
+              <label variable="locator" form="short"/>
+              <text variable="locator"/>
+            </group>
+          </group>
+        </else>
+      </choose>
+    </layout>
+  </citation>
+</style>
+<<===== CSL =====<<
+
+
+>>===== INPUT =====>>
+[
+    {
+        "id": "ITEM-1",
+        "type": "book",
+        "author": [
+            {
+                "family": "Doe",
+                "given": "John"
+            }
+        ],
+        "issued": {
+            "date-parts": [
+                [
+                    "1984"
+                ]
+            ]
+        },
+        "title": "Title"
+    }
+]
+<<===== INPUT =====<<
+
+
+>>===== VERSION =====>>
+1.0
+<<===== VERSION =====<<


### PR DESCRIPTION
This patch fixes issue #142.

In the original code, `item.locator.label` raises `VariableError` since there is no `locator` in the CitationItem. This error is then ignored in `process_children()` called in `Layout.render_citation()`, which causes empty output.

https://github.com/citeproc-py/citeproc-py/blob/d7fb0a0ff1a9858d15f83c5561e9846dce920699/citeproc/model.py#L1470-L1472

https://github.com/citeproc-py/citeproc-py/blob/d7fb0a0ff1a9858d15f83c5561e9846dce920699/citeproc/model.py#L551-L556