### PR TITLE
fix ordinal numbers

### DIFF
--- a/citeproc/model.py
+++ b/citeproc/model.py
@@ -1529,7 +1529,7 @@ def to_ordinal(number, context):
     if last_digit in (1, 2, 3) and not (len(number) > 1 and number[-2] == '1'):
         ordinal_term = 'ordinal-{:02}'.format(last_digit)
     else:
-        ordinal_term = 'ordinal-04'
+        ordinal_term = 'ordinal-11'
     return number + context.get_term(ordinal_term).single
 
 

--- a/citeproc/model.py
+++ b/citeproc/model.py
@@ -95,7 +95,7 @@ class CitationStylesElement(SomewhatObjectifiedElement):
         return self.markup(self.process(*args, **kwargs))
 
     # TODO: Locale methods
-    def get_term(self, name, form=None, fallback_locale=True, zero_padded=False):
+    def get_term(self, name, form=None, zero_padded=False):
         if isinstance(self.get_root(), Locale):
             return self.get_root().get_term(name, form)
         else:
@@ -103,8 +103,6 @@ class CitationStylesElement(SomewhatObjectifiedElement):
                 try:
                     return locale.get_term(name, form, zero_padded=zero_padded)
                 except IndexError: # TODO: create custom exception
-                    if not fallback_locale:
-                        return None
                     continue
 
     def get_date(self, form):
@@ -160,7 +158,8 @@ class Style(CitationStylesElement):
         if language in PRIMARY_DIALECTS:
             add_system_locale(PRIMARY_DIALECTS[language])
         # 6) (locale files) default locale (en-US)
-        add_system_locale('en-US')
+        if not self.locales:
+            add_system_locale('en-US')
         for locale in self.locales:
             locale.style = self
 
@@ -1533,9 +1532,9 @@ def to_ordinal(number, context):
         ordinal_term = f'ordinal-{number:02}'
     else:
         ordinal_term = f'ordinal-{number}'
-    if context.get_term(ordinal_term, fallback_locale=False) is None:
+    if context.get_term(ordinal_term) is None:
         ordinal_term = f'ordinal-{int(str(number)[-1]):02}'
-        if context.get_term(ordinal_term, fallback_locale=False, zero_padded=True) is None:
+        if context.get_term(ordinal_term, zero_padded=True) is None:
             ordinal_term = f'ordinal'
     return str(number) + context.get_term(ordinal_term).single
 

--- a/citeproc/model.py
+++ b/citeproc/model.py
@@ -1529,7 +1529,7 @@ def to_ordinal(number, context):
     if last_digit in (1, 2, 3) and not (len(number) > 1 and number[-2] == '1'):
         ordinal_term = 'ordinal-{:02}'.format(last_digit)
     else:
-        ordinal_term = 'ordinal-11'
+        ordinal_term = 'ordinal'
     return number + context.get_term(ordinal_term).single
 
 

--- a/tests/test_bibliography.py
+++ b/tests/test_bibliography.py
@@ -11,30 +11,36 @@ from citeproc import (
 from unittest import TestCase
 from citeproc.source.bibtex.bibparse import BibTeXParser
 
-BIB = [
-    {
+template = {
         "type": "book",
-        "id": "1",
         "title": "La Rettorica",
         "author": [{"literal": "Brunetto Latini"}],
         "issued": {"date-parts": [[1968]]},
         "editor": [{"literal": "Francesco Maggini"}],
-        "edition": 4,
         "publisher": "Le Monnier",
         "location": "Firenze",
     }
-]
 
+def _pp(string):
+    return string.split(" ")[5]
 
 class TestBibliographyGeneration(TestCase):
     def test_generate(self):
-        bib = source.json.CiteProcJSON(BIB)
-        bib_style = CitationStylesStyle("harvard1")
-        bibliography = CitationStylesBibliography(bib_style, bib, formatter.plain)
-        citations = [CitationItem(item["id"]) for item in BIB]
-        bibliography.register(Citation(citations))
-        print(
-            "\n".join(
-                [str(x) for x in bibliography.style.render_bibliography(citations)]
+        for lg in ["en-US", "de-DE", "nl-NL", "fr-FR", "es-ES", "it-IT", "hi-IN"]:
+            bib_style = CitationStylesStyle("harvard1", lg)
+            entries = []
+            for edition in range(1,26):
+                template["id"] = str(edition)
+                template["edition"] = edition
+                entries.append(template.copy())
+            bib = source.json.CiteProcJSON(entries)
+            bibliography = CitationStylesBibliography(bib_style, bib, formatter.plain)
+            citations = [CitationItem(str(x)) for x in range(1,26)]
+            bibliography.register(Citation(citations))
+            print(lg)
+            print(
+                "\n".join(
+                    [_pp(x) for x in bibliography.style.render_bibliography(citations)]
+                )
             )
-        )
+            print("")

--- a/tests/test_bibliography.py
+++ b/tests/test_bibliography.py
@@ -1,0 +1,40 @@
+# coding: utf-8
+import os
+from citeproc import (
+    Citation,
+    CitationItem,
+    CitationStylesBibliography,
+    CitationStylesStyle,
+    formatter,
+    source,
+)
+from unittest import TestCase
+from citeproc.source.bibtex.bibparse import BibTeXParser
+
+BIB = [
+    {
+        "type": "book",
+        "id": "1",
+        "title": "La Rettorica",
+        "author": [{"literal": "Brunetto Latini"}],
+        "issued": {"date-parts": [[1968]]},
+        "editor": [{"literal": "Francesco Maggini"}],
+        "edition": 4,
+        "publisher": "Le Monnier",
+        "location": "Firenze",
+    }
+]
+
+
+class TestBibliographyGeneration(TestCase):
+    def test_generate(self):
+        bib = source.json.CiteProcJSON(BIB)
+        bib_style = CitationStylesStyle("harvard1")
+        bibliography = CitationStylesBibliography(bib_style, bib, formatter.plain)
+        citations = [CitationItem(item["id"]) for item in BIB]
+        bibliography.register(Citation(citations))
+        print(
+            "\n".join(
+                [str(x) for x in bibliography.style.render_bibliography(citations)]
+            )
+        )


### PR DESCRIPTION
English ordinals are complicated with their 1**st**, 2**nd**, 3**rd**, 4**th**. Weirdly enough, these ordinal suffixes are defined for 1-3 and 11-13 in the official CSL locales ([en-US](https://github.com/citation-style-language/locales/blob/e631a52dcea396be20d031b6456e91dba7772224/locales-en-US.xml#L184-L191), [en-GB](https://github.com/citation-style-language/locales/blob/e631a52dcea396be20d031b6456e91dba7772224/locales-en-GB.xml#L199-L206)). So the [`to_ordinal`](https://github.com/citeproc-py/citeproc-py/blob/d7fb0a0ff1a9858d15f83c5561e9846dce920699/citeproc/model.py#L1526-L1533) function fails miserably when it tries to generate an ordinal number larger than three, because it assumes `ordinal-04` to be defined. Changing the value to `ordinal-11` fixes the issue.