### PR TITLE
Fix ordinals so they work for more languages than just English

### DIFF
--- a/citeproc/model.py
+++ b/citeproc/model.py
@@ -102,8 +102,7 @@ class CitationStylesElement(SomewhatObjectifiedElement):
             for locale in self.get_root().locales:
                 try:
                     return locale.get_term(name, form, zero_padded=zero_padded)
-                except IndexError as e: # TODO: create custom exception
-                    print(name, form, e, locale.attrib)
+                except IndexError: # TODO: create custom exception
                     continue
 
     def get_date(self, form):
@@ -159,7 +158,6 @@ class Style(CitationStylesElement):
         if language in PRIMARY_DIALECTS:
             add_system_locale(PRIMARY_DIALECTS[language])
         # 6) (locale files) default locale (en-US)
-        # if not self.locales:
         add_system_locale('en-US')
         for locale in self.locales:
             locale.style = self
@@ -180,11 +178,7 @@ class Locale(CitationStylesElement):
             attributes += "and not(@match='last-two-digits')"
         expr = './cs:term[{}]'.format(attributes)
         try:
-            res = self.terms.xpath_search(expr)
-            if not res:
-                print(f"Not found: {expr}")
-                raise IndexError
-            return res[0]
+            return self.terms.xpath_search(expr)[0]
         except AttributeError:
             raise IndexError
 
@@ -760,7 +754,6 @@ class Text(CitationStylesElement, FormatNumber, Formatted, Affixed, Quoted,
         if form == 'long':
             form = None
         term = self.get_term(self.get('term'), form)
-        print("_term:", item, form, term)
         if plural:
             text = term.multiple
         else:

--- a/citeproc/model.py
+++ b/citeproc/model.py
@@ -1529,7 +1529,7 @@ def to_ordinal(number, context):
     if last_digit in (1, 2, 3) and not (len(number) > 1 and number[-2] == '1'):
         ordinal_term = 'ordinal-{:02}'.format(last_digit)
     else:
-        ordinal_term = 'ordinal-04'
+        ordinal_term = 'ordinal-11'
     return number + context.get_term(ordinal_term).single
 
 

--- a/citeproc/model.py
+++ b/citeproc/model.py
@@ -102,7 +102,8 @@ class CitationStylesElement(SomewhatObjectifiedElement):
             for locale in self.get_root().locales:
                 try:
                     return locale.get_term(name, form, zero_padded=zero_padded)
-                except IndexError: # TODO: create custom exception
+                except IndexError as e: # TODO: create custom exception
+                    print(name, form, e, locale.attrib)
                     continue
 
     def get_date(self, form):
@@ -158,8 +159,8 @@ class Style(CitationStylesElement):
         if language in PRIMARY_DIALECTS:
             add_system_locale(PRIMARY_DIALECTS[language])
         # 6) (locale files) default locale (en-US)
-        if not self.locales:
-            add_system_locale('en-US')
+        # if not self.locales:
+        add_system_locale('en-US')
         for locale in self.locales:
             locale.style = self
 
@@ -179,7 +180,11 @@ class Locale(CitationStylesElement):
             attributes += "and not(@match='last-two-digits')"
         expr = './cs:term[{}]'.format(attributes)
         try:
-            return self.terms.xpath_search(expr)[0]
+            res = self.terms.xpath_search(expr)
+            if not res:
+                print(f"Not found: {expr}")
+                raise IndexError
+            return res[0]
         except AttributeError:
             raise IndexError
 
@@ -755,7 +760,7 @@ class Text(CitationStylesElement, FormatNumber, Formatted, Affixed, Quoted,
         if form == 'long':
             form = None
         term = self.get_term(self.get('term'), form)
-
+        print("_term:", item, form, term)
         if plural:
             text = term.multiple
         else:

--- a/citeproc/model.py
+++ b/citeproc/model.py
@@ -95,7 +95,7 @@ class CitationStylesElement(SomewhatObjectifiedElement):
         return self.markup(self.process(*args, **kwargs))
 
     # TODO: Locale methods
-    def get_term(self, name, form=None, fallback_locale=True, zero_padded=False):
+    def get_term(self, name, form=None, zero_padded=False):
         if isinstance(self.get_root(), Locale):
             return self.get_root().get_term(name, form)
         else:
@@ -103,8 +103,6 @@ class CitationStylesElement(SomewhatObjectifiedElement):
                 try:
                     return locale.get_term(name, form, zero_padded=zero_padded)
                 except IndexError: # TODO: create custom exception
-                    if not fallback_locale:
-                        return None
                     continue
 
     def get_date(self, form):
@@ -160,7 +158,8 @@ class Style(CitationStylesElement):
         if language in PRIMARY_DIALECTS:
             add_system_locale(PRIMARY_DIALECTS[language])
         # 6) (locale files) default locale (en-US)
-        add_system_locale('en-US')
+        if not self.locales:
+            add_system_locale('en-US')
         for locale in self.locales:
             locale.style = self
 
@@ -1533,9 +1532,9 @@ def to_ordinal(number, context):
         ordinal_term = f'ordinal-{number:02}'
     else:
         ordinal_term = f'ordinal-{number}'
-    if context.get_term(ordinal_term, fallback_locale=False) is None:
+    if context.get_term(ordinal_term) is None:
         ordinal_term = f'ordinal-{int(str(number)[-1]):02}'
-        if context.get_term(ordinal_term, fallback_locale=False, zero_padded=True) is None:
+        if context.get_term(ordinal_term, zero_padded=True) is None:
             ordinal_term = f'ordinal'
     return str(number) + context.get_term(ordinal_term).single
 

--- a/citeproc/model.py
+++ b/citeproc/model.py
@@ -1529,7 +1529,7 @@ def to_ordinal(number, context):
     if last_digit in (1, 2, 3) and not (len(number) > 1 and number[-2] == '1'):
         ordinal_term = 'ordinal-{:02}'.format(last_digit)
     else:
-        ordinal_term = 'ordinal-11'
+        ordinal_term = 'ordinal'
     return number + context.get_term(ordinal_term).single
 
 

--- a/tests/test_bibliography.py
+++ b/tests/test_bibliography.py
@@ -26,35 +26,33 @@ def _pp(string):
 
 class TestBibliographyGeneration(TestCase):
     def test_generate(self):
-        # for lg in ["en-US", "de-DE"]:
-        for lg in ["en-US", "de-DE", "nl-NL", "fr-FR", "es-ES", "it-IT", "hi-IN"]:
-            print(lg)
+        expected_ordinals = {
+            "en-US": {0: "1st", 1: "2nd"},
+            "de-DE": {0: "1."},
+            "es-ES": {0: "1.ª"},
+            "fr-FR": {0: "1ʳᵉ"},
+            "hi-IN": {0: "1"},
+            "it-IT": {0: "1º"}
+        }
+
+        for lg, ordinals in expected_ordinals.items():
             bib_style = CitationStylesStyle("harvard1", lg)
             entries = []
-            for edition in range(1,26):
+            for edition in range(1, 26):
                 template["id"] = str(edition)
                 template["edition"] = edition
                 entries.append(template.copy())
             bib = source.json.CiteProcJSON(entries)
             bibliography = CitationStylesBibliography(bib_style, bib, formatter.plain)
-            citations = [CitationItem(str(x)) for x in range(1,26)]
+            citations = [CitationItem(str(x)) for x in range(1, 26)]
             bibliography.register(Citation(citations))
-            ordinals = [_pp(x) for x in bibliography.style.render_bibliography(citations)]
-            # print(ordinals)
-            if lg == "en-US":
-                assert ordinals[0] == "1st"
-            if lg == "de-DE":
-                assert ordinals[0] == "1."
-            if lg == "es-ES":
-                assert ordinals[0] == "1.ª"
-            if lg == "fr-FR":
-                assert ordinals[0] == "1ʳᵉ"
-            if lg == "hi-IN":
-                assert ordinals[0] == "1"
-            if lg == "it-IT":
-                assert ordinals[0] == "1º"
+            generated_ordinals = [_pp(x) for x in bibliography.style.render_bibliography(citations)]
+            
+            for index, expected_value in ordinals.items():
+                assert generated_ordinals[index] == expected_value, f"Failed for {lg} at index {index}. Expected: {expected_value}, Got: {generated_ordinals[index]}"
+
             # print(lg,
-            #     "\n".join(
+            #     " ".join(
             #         ordinals
             #     )
             # )

--- a/tests/test_bibliography.py
+++ b/tests/test_bibliography.py
@@ -26,7 +26,9 @@ def _pp(string):
 
 class TestBibliographyGeneration(TestCase):
     def test_generate(self):
+        # for lg in ["en-US", "de-DE"]:
         for lg in ["en-US", "de-DE", "nl-NL", "fr-FR", "es-ES", "it-IT", "hi-IN"]:
+            print(lg)
             bib_style = CitationStylesStyle("harvard1", lg)
             entries = []
             for edition in range(1,26):
@@ -37,10 +39,22 @@ class TestBibliographyGeneration(TestCase):
             bibliography = CitationStylesBibliography(bib_style, bib, formatter.plain)
             citations = [CitationItem(str(x)) for x in range(1,26)]
             bibliography.register(Citation(citations))
-            print(lg)
-            print(
-                "\n".join(
-                    [_pp(x) for x in bibliography.style.render_bibliography(citations)]
-                )
-            )
-            print("")
+            ordinals = [_pp(x) for x in bibliography.style.render_bibliography(citations)]
+            # print(ordinals)
+            if lg == "en-US":
+                assert ordinals[0] == "1st"
+            if lg == "de-DE":
+                assert ordinals[0] == "1."
+            if lg == "es-ES":
+                assert ordinals[0] == "1.ª"
+            if lg == "fr-FR":
+                assert ordinals[0] == "1ʳᵉ"
+            if lg == "hi-IN":
+                assert ordinals[0] == "1"
+            if lg == "it-IT":
+                assert ordinals[0] == "1º"
+            # print(lg,
+            #     "\n".join(
+            #         ordinals
+            #     )
+            # )

--- a/tests/test_bibliography.py
+++ b/tests/test_bibliography.py
@@ -11,30 +11,36 @@ from citeproc import (
 from unittest import TestCase
 from citeproc.source.bibtex.bibparse import BibTeXParser
 
-BIB = [
-    {
+template = {
         "type": "book",
-        "id": "1",
         "title": "La Rettorica",
         "author": [{"literal": "Brunetto Latini"}],
         "issued": {"date-parts": [[1968]]},
         "editor": [{"literal": "Francesco Maggini"}],
-        "edition": 4,
         "publisher": "Le Monnier",
         "location": "Firenze",
     }
-]
 
+def _pp(string):
+    return string.split(" ")[5]
 
 class TestBibliographyGeneration(TestCase):
     def test_generate(self):
-        bib = source.json.CiteProcJSON(BIB)
-        bib_style = CitationStylesStyle("harvard1")
-        bibliography = CitationStylesBibliography(bib_style, bib, formatter.plain)
-        citations = [CitationItem(item["id"]) for item in BIB]
-        bibliography.register(Citation(citations))
-        print(
-            "\n".join(
-                [str(x) for x in bibliography.style.render_bibliography(citations)]
+        for lg in ["en-US", "de-DE", "nl-NL", "fr-FR", "es-ES", "it-IT", "hi-IN"]:
+            bib_style = CitationStylesStyle("harvard1", lg)
+            entries = []
+            for edition in range(1,26):
+                template["id"] = str(edition)
+                template["edition"] = edition
+                entries.append(template.copy())
+            bib = source.json.CiteProcJSON(entries)
+            bibliography = CitationStylesBibliography(bib_style, bib, formatter.plain)
+            citations = [CitationItem(str(x)) for x in range(1,26)]
+            bibliography.register(Citation(citations))
+            print(lg)
+            print(
+                "\n".join(
+                    [_pp(x) for x in bibliography.style.render_bibliography(citations)]
+                )
             )
-        )
+            print("")

--- a/tests/test_bibliography.py
+++ b/tests/test_bibliography.py
@@ -27,10 +27,10 @@ def _pp(string):
 class TestBibliographyGeneration(TestCase):
     def test_generate(self):
         expected_ordinals = {
-            "en-US": {0: "1st", 1: "2nd"},
-            "de-DE": {0: "1."},
+            "en-US": {0: "1st", 1: "2nd", 3: "4th", 19: "20th"},
+            "de-DE": {0: "1.", 9: "10."},
             "es-ES": {0: "1.ª"},
-            "fr-FR": {0: "1ʳᵉ"},
+            "fr-FR": {0: "1ʳᵉ", 9: "10ᵉ"},
             "hi-IN": {0: "1"},
             "it-IT": {0: "1º"}
         }

--- a/tests/test_bibliography.py
+++ b/tests/test_bibliography.py
@@ -1,0 +1,40 @@
+# coding: utf-8
+import os
+from citeproc import (
+    Citation,
+    CitationItem,
+    CitationStylesBibliography,
+    CitationStylesStyle,
+    formatter,
+    source,
+)
+from unittest import TestCase
+from citeproc.source.bibtex.bibparse import BibTeXParser
+
+BIB = [
+    {
+        "type": "book",
+        "id": "1",
+        "title": "La Rettorica",
+        "author": [{"literal": "Brunetto Latini"}],
+        "issued": {"date-parts": [[1968]]},
+        "editor": [{"literal": "Francesco Maggini"}],
+        "edition": 4,
+        "publisher": "Le Monnier",
+        "location": "Firenze",
+    }
+]
+
+
+class TestBibliographyGeneration(TestCase):
+    def test_generate(self):
+        bib = source.json.CiteProcJSON(BIB)
+        bib_style = CitationStylesStyle("harvard1")
+        bibliography = CitationStylesBibliography(bib_style, bib, formatter.plain)
+        citations = [CitationItem(item["id"]) for item in BIB]
+        bibliography.register(Citation(citations))
+        print(
+            "\n".join(
+                [str(x) for x in bibliography.style.render_bibliography(citations)]
+            )
+        )


### PR DESCRIPTION
Thank you for the feedback and the detective work (moved from [PR 145](https://github.com/citeproc-py/citeproc-py/pull/145).)
Looking at `to_ordinal()` again, it does not only fail for ordinals `> 3` in English, the entire function is also written **specifically for English** (or languages patterning like English I guess):

```python
def to_ordinal(number, context):
    number = str(number)
    last_digit = int(number[-1])
    if last_digit in (1, 2, 3) and not (len(number) > 1 and number[-2] == '1'):
        ordinal_term = 'ordinal-{:02}'.format(last_digit)
    else:
        ordinal_term = 'ordinal' # or 'ordinal-11' or 'ordinal-04'... 
    return number + context.get_term(ordinal_term).single
```

The long conditional describes numbers `X1`, `X2`, `X3` where `X!=11` -- i.e. **1st 2nd 3rd**, but not **11th 12th 13th**, but then again **21st 22nd 23rd** etc.
Of course, for other languages this makes no sense, for instance Dutch has **1ste, 2de, 3de** [...] **11de 12de 13de** [...] **21ste 22ste 23ste**; this means that `12` (*twaalfde*) and `13` pattern like `2` (*tweede*) and 3, but not like 22 (*tweeëntwintigste*) and 23, which is pretty much the opposite pattern from English.

Skimming through different locales and generating ordinals, I quickly realized that there was another problem: [if no ordinal term is found for a locale, it falls back to `en-US`](https://github.com/citeproc-py/citeproc-py/blob/d7fb0a0ff1a9858d15f83c5561e9846dce920699/citeproc/model.py#L98-L106).
This might make sense for other terms (? I have not looked at them), but it certainly doesn't for numbers.
To illustrate, [French](https://github.com/citation-style-language/locales/blob/e631a52dcea396be20d031b6456e91dba7772224/locales-fr-FR.xml#L196-L199) has no definition for `ordinal-22` (because it's all **Xᵉ** except `1`); what should happen is that in its absence we fall back to `ordinal`, but what happens instead is that we get **22nd**!
My solution here was to make the last-minute addition of the `en-US` locale dependent on there *not already being any other locales*.
(We also get **21ʳᵉ** because the English-centric function assumes that it should be like the ordinal for `1`, **1ʳᵉ**.
)
Long story short, I've rewritten `to_ordinal()` from scratch:

```python
def to_ordinal(number, context):
    if len(str(number)) == 1:
        ordinal_term = f'ordinal-{number:02}'
    else:
        ordinal_term = f'ordinal-{number}'
    if context.get_term(ordinal_term) is None:
        ordinal_term = f'ordinal-{int(str(number)[-1]):02}'
        if context.get_term(ordinal_term, zero_padded=True) is None:
            ordinal_term = f'ordinal'
    return str(number) + context.get_term(ordinal_term).single
```

It first pads single digits; if no term is found it tries a truncated and zero-padded last digit, e.g. `03` for `23`.
If this does not work, it falls back to `ordinal`.
I've also added a new argument `zero_padded` to `get_term()`, because for instance [Dutch](https://github.com/citation-style-language/locales/blob/e631a52dcea396be20d031b6456e91dba7772224/locales-nl-NL.xml#L194-L213) specifies that e.g. `ordinal-05` should not match `25`, using the attribute `match='last-two-digits'` (instead of the default `'last-digit'`); `get_term()` needs to take that into account.
This PR not only fixes the issue I originally set out to solve (English `> 3`), but also ordinals in most of the languages I looked at (the first column of a language is result of the current implementation of `to_ordinal`, the second column the result of my replacement suggestion):

en-US | [nl-NL](https://github.com/citation-style-language/locales/blob/e631a52dcea396be20d031b6456e91dba7772224/locales-nl-NL.xml#L194-L213) |   | [es-ES](https://github.com/citation-style-language/locales/blob/e631a52dcea396be20d031b6456e91dba7772224/locales-es-ES.xml#L193-L194) |   | [fr-FR](https://github.com/citation-style-language/locales/blob/e631a52dcea396be20d031b6456e91dba7772224/locales-fr-FR.xml#L196-L199) |   | [de-DE](https://github.com/citation-style-language/locales/blob/e631a52dcea396be20d031b6456e91dba7772224/locales-de-DE.xml#L205-L206) |   | [hi-IN](https://github.com/citation-style-language/locales/blob/e631a52dcea396be20d031b6456e91dba7772224/locales-hi-IN.xml#L194-L200) |   | [it-IT](https://github.com/citation-style-language/locales/blob/e631a52dcea396be20d031b6456e91dba7772224/locales-it-IT.xml#L196-L199) |  
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
1st | 1st | 1ste | 1st | 1.ª | 1ʳᵉ | 1ʳᵉ | 1st | 1. | 1 | 1 | 1st | 1º
2nd | 2de | 2de | 2nd | 2.ª | 2nd | 2ᵉ | 2nd | 2. | 2 | 2 | 2nd | 2º
3rd | 3de | 3de | 3rd | 3.ª | 3rd | 3ᵉ | 3rd | 3. | 3 | 3 | 3rd | 3º
4th | 4ste | 4de | 4.ª | 4.ª | 4ᵉ | 4ᵉ | 4. | 4. | 4वाँ | 4 | 4º | 4º
5th | 5ste | 5de | 5.ª | 5.ª | 5ᵉ | 5ᵉ | 5. | 5. | 5वाँ | 5वाँ | 5º | 5º
6th | 6ste | 6de | 6.ª | 6.ª | 6ᵉ | 6ᵉ | 6. | 6. | 6वाँ | 6 | 6º | 6º
7th | 7ste | 7de | 7.ª | 7.ª | 7ᵉ | 7ᵉ | 7. | 7. | 7वाँ | 7वाँ | 7º | 7º
8th | 8ste | 8ste | 8.ª | 8.ª | 8ᵉ | 8ᵉ | 8. | 8. | 8वाँ | 8वाँ | 8º | 8º
9th | 9ste | 9de | 9.ª | 9.ª | 9ᵉ | 9ᵉ | 9. | 9. | 9वाँ | 9वाँ | 9º | 9º
10th | 10ste | 10de | 10.ª | 10.ª | 10ᵉ | 10ᵉ | 10. | 10. | 10वाँ | 10वाँ | 10º | 10º
11th | 11ste | 11de | 11.ª | 11.ª | 11ᵉ | 11ᵉ | 11. | 11. | 11वाँ | 11 | 11º | 11º
12th | 12ste | 12de | 12.ª | 12.ª | 12ᵉ | 12ᵉ | 12. | 12. | 12वाँ | 12 | 12º | 12º
13th | 13ste | 13de | 13.ª | 13.ª | 13ᵉ | 13ᵉ | 13. | 13. | 13वाँ | 13 | 13º | 13º
14th | 14ste | 14de | 14.ª | 14.ª | 14ᵉ | 14ᵉ | 14. | 14. | 14वाँ | 14 | 14º | 14º
15th | 15ste | 15de | 15.ª | 15.ª | 15ᵉ | 15ᵉ | 15. | 15. | 15वाँ | 15वाँ | 15º | 15º
16th | 16ste | 16de | 16.ª | 16.ª | 16ᵉ | 16ᵉ | 16. | 16. | 16वाँ | 16 | 16º | 16º
17th | 17ste | 17de | 17.ª | 17.ª | 17ᵉ | 17ᵉ | 17. | 17. | 17वाँ | 17वाँ | 17º | 17º
18th | 18ste | 18de | 18.ª | 18.ª | 18ᵉ | 18ᵉ | 18. | 18. | 18वाँ | 18वाँ | 18º | 18º
19th | 19ste | 19de | 19.ª | 19.ª | 19ᵉ | 19ᵉ | 19. | 19. | 19वाँ | 19वाँ | 19º | 19º
20th | 20ste | 20ste | 20.ª | 20.ª | 20ᵉ | 20ᵉ | 20. | 20. | 20वाँ | 20वाँ | 20º | 20º
21st | 21st | 21ste | 21st | 21.ª | 21ʳᵉ | 21ᵉ | 21st | 21. | 21 | 21 | 21st | 21º
22nd | 22de | 22ste | 22nd | 22.ª | 22nd | 22ᵉ | 22nd | 22. | 22 | 22 | 22nd | 22º
23rd | 23de | 23ste | 23rd | 23.ª | 23rd | 23ᵉ | 23rd | 23. | 23 | 23 | 23rd | 23º
24th | 24ste | 24ste | 24.ª | 24.ª | 24ᵉ | 24ᵉ | 24. | 24. | 24वाँ | 24 | 24º | 24º
25th | 25ste | 25ste | 25.ª | 25.ª | 25ᵉ | 25ᵉ | 25. | 25. | 25वाँ | 25वाँ | 25º | 25º

Italian is still completely wrong because it should be **Xª** (*edizione* being feminine), but that's either a different issue or something to fix in the locale (note that Spanish gets it right by defining an "ungendered"/default `ordinal` **ª**).
Punjabi, which @yarikoptic mentioned is not included in the version CSL linked to citeproc-py, so yet another issue.
Finally, note that the orthographic convention for many languages not shown here is not to combine digits with suffixes, simply using `.` like German.