### PR TITLE
FormatNumber fails for Chicago style with roman numbers

### DIFF
--- a/citeproc/model.py
+++ b/citeproc/model.py
@@ -666,6 +666,8 @@ class FormatNumber(object):
         common = find_common(first, last)
         if range_format == 'chicago':
             m = re.search(r'\d+', first)
+            if not m:
+                return last
             first_number = int(m.group())
             if first_number < 100 or first_number % 100 == 0:
                 range_format = 'expanded'


### PR DESCRIPTION
The problem can be simulated as

```
import re

first = 'I'  # or another roman number
m = re.search(r'\d+', first)
first_number = int(m.group())
```

In this case `m is None`