### PR TITLE
release: switch to using GitHub App to overcome branch protection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,12 @@ jobs:
   auto-release:
     runs-on: ubuntu-latest
     steps:
+      - id: create_token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
+
       - name: Checkout source
         uses: actions/checkout@v4
         with:
@@ -38,7 +44,7 @@ jobs:
           fi
           ~/auto shipit -vv $opts
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.create_token.outputs.token }}
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
 


### PR DESCRIPTION
There isn't a good way to allow GITHUB_TOKEN to bypass branch protection rules. I've added a GitHub App that should have the correct permissions. I don't have a good way to test this before merging, so we might have to make some adjustments.