### PR TITLE
release: use GitHUb App token for checkout and push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.create_token.outputs.token }}
 
       - name: Download latest auto
         run: |


### PR DESCRIPTION
I think the GitHub App token will work for the push if it's used on the checkout step.