### PR TITLE
release: checkout with submodules

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          submodules: true
           token: ${{ steps.create_token.outputs.token }}
 
       - name: Download latest auto


### PR DESCRIPTION
We do the same in test, but missed here:

```
❯ git grep -4 submodule .github/workflows/test.yml
.github/workflows/test.yml-      - name: Check out repository
.github/workflows/test.yml-        uses: actions/checkout@v4
.github/workflows/test.yml-        with:
.github/workflows/test.yml-          fetch-depth: 0
.github/workflows/test.yml:          submodules: true
```