### PR TITLE
Instruct that long description is in markdown and not ReST

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ setup(
     author_email='brecht@mos6581.org',
     description='Citations and bibliography formatter',
     long_description=long_description(),
+    long_description_content_type='text/markdown',
     url='https://github.com/brechtm/citeproc-py',
     keywords='csl citation html rst bibtex xml',
     license='2-clause BSD License',


### PR DESCRIPTION
more information on why I think this should fix it (didn't try on test pypi): https://packaging.python.org/en/latest/guides/making-a-pypi-friendly-readme/

that one likes ReST and not markdown, so now we have it not rendered:

![Image](https://github.com/user-attachments/assets/9281a3c3-19cf-4206-a4ad-a5925814ee05)

whenever previously ReST was rendered

![Image](https://github.com/user-attachments/assets/063e239d-a0cb-4fe0-b879-e84cf7d9292e)