### PR TITLE
coveralls: try to reenable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,6 @@ jobs:
         run: tox
         env:
           # Needed for coveralls:
-          GITHUB_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 # vim:set et sts=2:

--- a/tox.ini
+++ b/tox.ini
@@ -28,5 +28,4 @@ commands =
     nosetests --where={toxinidir}/tests --ignore-files=citeproc-test.py \
               --with-coverage --cover-package=citeproc
     coverage run --source=citeproc --append {toxinidir}/tests/citeproc-test.py
-    # TODO: switch to codecov
-    # python {toxinidir}/coveralls.py || :
+    python {toxinidir}/coveralls.py || :


### PR DESCRIPTION
This change was sufficient to fix coveralls, and it's tied to the citeproc-py repo so everyone with github access should be able to see the reports. I don't have strong feelings about coverage tools, but this should fix the badge on the readme.