### PR TITLE
fix and spacing issue

### DIFF
--- a/citeproc/model.py
+++ b/citeproc/model.py
@@ -1247,7 +1247,7 @@ class Name(CitationStylesElement, Formatted, Affixed, Delimited):
                 if (delimiter_precedes_last == 'always' or
                     (delimiter_precedes_last == 'contextual' and
                      len(output) > 2)):
-                        text = self.join([text, ''])
+                        text = self.join([text, ''], ', ')
                 else:
                     text += ' '
                 text += '{} '.format(and_term) + output[-1]


### PR DESCRIPTION
This was reported a long time ago https://github.com/citeproc-py/citeproc-py/issues/166. On some formats there would be missing spaces around "and" in the author list. 

Claude diagnosed this as a missing default for some of the delimiter options.

This fixes the issue, and doesn't cause any additional test failures.