### PR TITLE
Normalize seams on the plain str concatenation paths too

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,9 @@ cite references and render the bibliography.
 
 ## CSL Compatibility
 
-Currently, citeproc-py passes almost 60% of the (relevant) tests in the
+Currently, citeproc-py passes about 60% of the tests in the
 [citeproc-test suite](https://github.com/citation-style-language/test-suite).
-However, it is more than 60% complete, as
-citeproc-py doesn't take care of double spaces and repeated punctuation
-marks yet, making a good deal of the tests fail. In addition, the
-following features have not yet been implemented (there are probably
-some I forgot though):
+A non-exhaustive list of functionality that is missing includes:
 
 -  disambiguation/year-suffix
 -  et-al-subsequent-min/et-al-subsequent-use-first

--- a/citeproc/model.py
+++ b/citeproc/model.py
@@ -11,7 +11,7 @@ from lxml import etree
 
 from . import NAMES, DATES, NUMBERS, PRIMARY_DIALECTS, LANGUAGE_NAMES
 from .source import VariableError, DateRange, LiteralDate
-from .string import String, join
+from .string import String, join, concat
 
 
 # Base class
@@ -341,7 +341,7 @@ class Affixed(object):
         if string is not None:
             prefix = self.get('prefix', '')
             suffix = self.get('suffix', '')
-            return prefix + string + suffix
+            return concat(concat(prefix, string), suffix)
         return None
 
 

--- a/citeproc/string.py
+++ b/citeproc/string.py
@@ -43,6 +43,19 @@ def _strip_first_char(other):
     return type(other)(str(other)[1:])
 
 
+def concat(left, right):
+    """Append `right` to `left`, normalizing the seam between them.
+
+    String and MixedString normalize the seam in their own ``__add__``; the
+    formatters hand back plain ``str``, which does not, so do it here.
+    """
+    if isinstance(left, (String, MixedString)) or isinstance(right, (String, MixedString)):
+        return left + right
+    if not left or not right:
+        return left + right
+    return left + normalize_seam(left, right)
+
+
 def discard_empty_other(method):
     """Decorator for addition operator methods that returns the object itself if
     `other` is the empty string."""
@@ -172,4 +185,4 @@ class NoCase(String):
 
 
 def join(items, delimiter=''):
-    return reduce(lambda a, b: a + delimiter + b, items)
+    return reduce(lambda a, b: concat(concat(a, delimiter), b), items)

--- a/citeproc/string.py
+++ b/citeproc/string.py
@@ -2,6 +2,47 @@
 from functools import wraps, reduce
 
 
+# Punctuation characters that should not be duplicated when two of them end up
+# adjacent at a concatenation seam (e.g. a suffix '.' following text that
+# already ends in '.').
+SEAM_PUNCTUATION = frozenset('.,;:!?')
+
+
+def normalize_seam(left, other):
+    """Adjust the leading characters of `other` so that concatenating it onto
+    `left` does not introduce a double space or a duplicated punctuation mark.
+
+    `left` is the accumulated string so far and `other` the piece about to be
+    appended. Only the boundary between them is considered; the interior of
+    either side (e.g. an ellipsis inside a title) is never touched. Markup
+    segments start with '<', so they are left alone. Returns `other`, possibly
+    with its first character removed."""
+    left = str(left)
+    other_str = str(other)
+    if not left or not other_str:
+        return other
+    last, first = left[-1], other_str[0]
+    # collapse a double space
+    if last == ' ' and first == ' ':
+        return _strip_first_char(other)
+    # drop a duplicated punctuation mark ('..' -> '.', ',,' -> ',', ...)
+    if last == first and first in SEAM_PUNCTUATION:
+        return _strip_first_char(other)
+    return other
+
+
+def _strip_first_char(other):
+    """Return a copy of `other` with its first character removed, preserving
+    the (Mixed)String segment structure."""
+    if isinstance(other, MixedString):
+        segments = list(other)
+        head = segments[0]
+        stripped = type(head)(str(head)[1:])
+        segments[0:1] = [stripped] if stripped != '' else []
+        return MixedString(segments)
+    return type(other)(str(other)[1:])
+
+
 def discard_empty_other(method):
     """Decorator for addition operator methods that returns the object itself if
     `other` is the empty string."""
@@ -55,6 +96,9 @@ class String(str):
 class MixedString(list):
     @discard_empty_other
     def __add__(self, other):
+        other = normalize_seam(self, other)
+        if other == '' or other == []:
+            return self
         super_obj = super(MixedString, self)
         try:
             return self.__class__(super_obj.__add__(other))

--- a/tests/failing_tests.txt
+++ b/tests/failing_tests.txt
@@ -6,7 +6,6 @@ affix_MovingPunctuation
 affix_PrefixWithDecorations
 affix_SpaceWithQuotes
 affix_WithCommas
-bugreports_AllCapsLeakage
 bugreports_ApostropheOnParticle
 bugreports_AsaSpacing
 bugreports_AsmJournals
@@ -27,7 +26,6 @@ bugreports_DisambiguationAddNamesBibliography
 bugreports_DoubleEncodedAngleBraces
 bugreports_DuplicateSpaces
 bugreports_DuplicateSpaces2
-bugreports_DuplicateSpaces3
 bugreports_DuplicateTerminalPunctuationInBibliography
 bugreports_EnvAndUrb
 bugreports_EtAlSubsequent
@@ -36,7 +34,6 @@ bugreports_FrenchApostrophe
 bugreports_GreekStyleProblems                                      # uncaught exception
 bugreports_GreekStyleTwoEditors                                    # uncaught exception
 bugreports_IeeePunctuation
-bugreports_LabelsOutOfPlace
 bugreports_LegislationCrash
 bugreports_MatchedAuthorAndDate
 bugreports_MovePunctuationInsideQuotesForLocator
@@ -53,7 +50,6 @@ bugreports_SortedIeeeItalicsFail
 bugreports_StyleError001
 bugreports_ThesisUniversityAppearsTwice
 bugreports_TitleCase
-bugreports_UndefinedBeforeVal
 bugreports_UndefinedInName3
 bugreports_UndefinedNotString
 bugreports_UndefinedStr
@@ -61,7 +57,6 @@ bugreports_YearSuffixInHarvard1
 bugreports_YearSuffixLingers
 bugreports_disambigHang
 bugreports_ikeyOne
-bugreports_parenthesis
 bugreports_parseName
 collapse_AuthorCollapse
 collapse_AuthorCollapseNoDate
@@ -87,7 +82,6 @@ date_RangeDelimiter
 date_VariousInvalidDates                                           # uncaught exception
 date_YearSuffixDelimiter
 date_YearSuffixImplicitWithNoDate
-date_YearSuffixImplicitWithNoDateOneOnly
 date_YearSuffixWithNoDate
 decorations_AndTermUnaffectedByNameDecorations
 decorations_Baseline
@@ -149,10 +143,8 @@ disambiguate_YearSuffixWithEtAlSubsequent
 disambiguate_YearSuffixWithMixedCreatorTypes
 display_AuthorAsHeading
 display_DisplayBlock
-display_LostSuffix
 display_SecondFieldAlignClone
 display_SecondFieldAlignMigratePunctuation
-etal_CitationAndBibliographyDecorationsInBibliography
 etal_UseZeroFirst
 flipflop_ApostropheInsideTag
 flipflop_Apostrophes
@@ -264,7 +256,6 @@ name_SubsequentAuthorSubstituteMultipleNames
 name_SubsequentAuthorSubstituteSingleField
 name_SubstituteInheritLabel
 name_SubstitutePartialEach
-name_TwoRolesSameRenderingSeparateRoleLabels
 name_WithNonBreakingSpace
 name_namepartAffixes
 nameattr_EtAlUseFirstOnCitationInBibliography
@@ -290,7 +281,6 @@ position_IfIbidWithLocatorIsTrueThenIbidIsTrue
 position_NearNoteSameNote                                          # uncaught exception
 position_ResetNoteNumbers
 punctuation_DefaultYearSuffixDelimiter
-punctuation_DelimiterWithStripPeriodsAndSubstitute2
 punctuation_FieldDuplicates
 punctuation_FrenchOrthography
 punctuation_FullMontyField
@@ -304,7 +294,6 @@ quotes_Punctuation
 quotes_PunctuationNasty
 quotes_PunctuationWithInnerQuote
 quotes_QuotesUnderQuotesFalse
-simplespace_case1
 sort_AguStyle
 sort_AguStyleReverseGroups
 sort_AuthorDateWithYearSuffix

--- a/tests/failing_tests.txt
+++ b/tests/failing_tests.txt
@@ -9,7 +9,6 @@ affix_WithCommas
 bugreports_ApostropheOnParticle
 bugreports_AsaSpacing
 bugreports_AsmJournals
-bugreports_AuthorPosition
 bugreports_AutomaticallyDeleteItemsFails
 bugreports_BadCitationUpdate
 bugreports_BadDelimiterBeforeCollapse
@@ -166,7 +165,6 @@ flipflop_StartingApostrophe
 fullstyles_ABdNT
 fullstyles_ChicagoArticleTitleQuestion
 fullstyles_ChicagoAuthorDateSimple
-group_ComplexNesting
 group_SuppressTermInMacro
 integration_DeleteName
 integration_DisambiguateAddGivenname1
@@ -288,7 +286,6 @@ punctuation_FullMontyPlain
 punctuation_FullMontyQuotesIn
 punctuation_FullMontyQuotesOut
 punctuation_OnMacro
-punctuation_SemicolonDelimiter
 punctuation_SuppressPrefixPeriodForDelimiterSemicolon
 quotes_Punctuation
 quotes_PunctuationNasty
@@ -328,7 +325,6 @@ textcase_LocaleUnicode
 textcase_Lowercase
 textcase_NoSpaceBeforeApostrophe
 textcase_NonEnglishChars
-textcase_RepeatedTitleBug
 textcase_SkipNameParticlesInTitleCase
 textcase_StopWordBeforeHyphen
 textcase_TitleCapitalization2

--- a/tests/local/term_EmptyValueForTermSkipsField.txt
+++ b/tests/local/term_EmptyValueForTermSkipsField.txt
@@ -10,7 +10,7 @@ bibliography
 
 >>===== RESULT =====>>
 <div class="csl-bib-body">
-  <div class="csl-entry">Doe, J.. (2015). <i>Page Title</i>. Website Title. https://example.com</div>
+  <div class="csl-entry">Doe, J. (2015). <i>Page Title</i>. Website Title. https://example.com</div>
 </div>
 <<===== RESULT =====<<
 

--- a/tests/test_string_seams.py
+++ b/tests/test_string_seams.py
@@ -1,0 +1,44 @@
+from unittest import TestCase
+
+from citeproc.model import Affixed
+from citeproc.string import String, join
+
+
+class Affix(Affixed):
+    """The smallest thing `Affixed.wrap` needs: something with a `get`."""
+
+    def __init__(self, prefix='', suffix=''):
+        self.values = {'prefix': prefix, 'suffix': suffix}
+
+    def get(self, name, default=None):
+        return self.values.get(name, default)
+
+
+class TestStringSeams(TestCase):
+    # A seam may hold either a str or a MixedString, and MixedString is a list
+    # of segments whose == compares as a list. Compare str(result), or the
+    # assertion silently stops being about the text.
+
+    def test_join_normalizes_delimiter_at_each_seam(self):
+        result = join(['Doe, J.', '(2001)', 'A book'], '. ')
+
+        self.assertEqual(str(result), 'Doe, J. (2001). A book')
+
+    def test_affixed_wrap_does_not_duplicate_suffix_punctuation(self):
+        result = Affix(suffix='.').wrap(String('Doe, J.'))
+
+        self.assertEqual(str(result), 'Doe, J.')
+
+    # A String normalizes the seam in its own __add__, so join and wrap have to
+    # defer to it rather than normalize a second time. Normalizing twice drops
+    # two characters where one was meant to go, which eats real content.
+
+    def test_join_drops_only_one_character_at_a_string_seam(self):
+        result = join([String('a.'), String('..b')], '')
+
+        self.assertEqual(str(result), 'a..b')
+
+    def test_wrap_drops_only_one_character_at_a_string_seam(self):
+        result = Affix(suffix='..').wrap(String('x.'))
+
+        self.assertEqual(str(result), 'x..')


### PR DESCRIPTION
Fixes #105. Supersedes #202, whose commits this includes unchanged. Opened per @tmorrell's suggestion in #105.

The seam normalization in #202 is reachable only from `MixedString.__add__`, but the pieces a style concatenates are plain `str` — the formatters' `preformat` returns one — so it never fires on the path that produces the doubled full stop after initials. Tested on its own, #202 leaves the case in #105 byte-identical to 0.10.3 in the plain, html and rst formatters.

In the APA case the doubling happens at a group delimiter in `Delimited.join`, joining `['Doe, J.', '(2001)', 'A book']` with a full stop and a space. The third commit here routes the two remaining concatenations through `normalize_seam`: the `reduce` in `string.join`, and the prefix/suffix concatenation in `Affixed.wrap`. Both defer to `__add__` when either side is already a `String` or `MixedString`, so behaviour there is unchanged.

**Test results**, citeproc-test run with `-n` (the runner rewrites `failing_tests.txt` by default, which masks the comparison):

- #202's commits alone: the 11 fixtures reported on that PR
- plus this commit: 4 further fixtures — `bugreports_AuthorPosition`, `group_ComplexNesting`, `punctuation_SemicolonDelimiter`, `textcase_RepeatedTitleBug` — and no new failures

One local fixture needed changing, and it is the part of this PR I would most like a second opinion on. `term_EmptyValueForTermSkipsField` expected `Doe, J..` in its bibliography entry. That doubling is incidental to what the fixture covers — an empty term value skipping its field — so I corrected the expected output rather than relaxing the change. If you would rather keep the fixture untouched, that is a reason to reconsider the approach, not to special-case it.

The fourth commit adds `tests/test_string_seams.py`, which names the two concatenation paths directly rather than inferring them from rendered citations. Its first two cases are taken from #208, which arrived at the same two insertion points independently; the other two pin the reason both sites defer to `__add__` when either side is already a `String`. Normalizing a seam that `__add__` will normalize again removes two characters where one was meant to go, so it eats content rather than punctuation — `join([String('a.'), String('..b')], '')` gives `a.b`, and `Affixed(suffix='..').wrap(String('x.'))` gives `x.`. Those two cases fail against #208 as it stands. All four compare through `str()`, because a seam may hold a `MixedString`, which is a list of segments whose `==` compares as a list — an assertion against a plain `str` then quietly stops being about the text.

Downstream check: this lets me drop the post-processing that collapsed the doubled full stop in my own rendering, and my 55 citation tests pass without it.
