### PR TITLE
Render cs:label only when the labelled variable is set

### DIFF
--- a/citeproc/model.py
+++ b/citeproc/model.py
@@ -1349,6 +1349,13 @@ class Label(CitationStylesElement, Formatted, Affixed, StrippedPeriods,
     def process(self, item, variable=None, plural=None, context=None, **kwargs):
         if variable is None:
             variable = self.get('variable')
+            # A cs:label that names its own variable renders the term only if
+            # that variable is non-empty. When cs:names passes the variable in
+            # it has already established that the name variable is set, and
+            # what it passes may be the "editortranslator" term rather than a
+            # variable at all -- so the check belongs here and not below.
+            if not self._variable_is_set(item, variable):
+                return None
         form = self.get('form', 'long')
         plural_option = self.get('plural', 'contextual')
         if plural is None:
@@ -1378,6 +1385,28 @@ class Label(CitationStylesElement, Formatted, Affixed, StrippedPeriods,
     # it is part of a single dotted number/version (e.g. "2.0"), which stays
     # singular ("Version 2.0", not "Versions 2.0").
     RE_MULTIPLE_NUMBERS = re.compile(r'\d+[^\d.]+\d+')
+
+    def _variable_is_set(self, item, variable):
+        """Whether the labelled variable holds a value for this item.
+
+        The lookup follows the one in `Text._variable`: `locator` lives on the
+        citation item rather than the reference, `citation-number` is generated
+        and is set for every registered item, and the `page-first` virtual
+        variable is derived from `page`.
+        """
+        if variable == 'locator':
+            return item.has_locator
+        elif variable == 'citation-number':
+            return True
+        elif variable.startswith('page'):
+            variable = 'page'
+
+        try:
+            value = item.reference[variable.replace('-', '_')]
+        except VariableError:
+            return False
+
+        return value is not None and str(value) != ''
 
     def _is_plural(self, item):
         variable = self.get('variable')

--- a/tests/failing_tests.txt
+++ b/tests/failing_tests.txt
@@ -31,7 +31,6 @@ bugreports_EtAlSubsequent
 bugreports_FourAndFour
 bugreports_FrenchApostrophe
 bugreports_GreekStyleProblems                                      # uncaught exception
-bugreports_GreekStyleTwoEditors                                    # uncaught exception
 bugreports_IeeePunctuation
 bugreports_LegislationCrash
 bugreports_MatchedAuthorAndDate
@@ -46,10 +45,8 @@ bugreports_SingleQuote
 bugreports_SmallCapsEscape
 bugreports_SortSecondaryKey
 bugreports_SortedIeeeItalicsFail
-bugreports_StyleError001
 bugreports_ThesisUniversityAppearsTwice
 bugreports_TitleCase
-bugreports_UndefinedInName3
 bugreports_UndefinedNotString
 bugreports_UndefinedStr
 bugreports_YearSuffixInHarvard1

--- a/tests/local/label_EmptyVariableSuppressesTerm.txt
+++ b/tests/local/label_EmptyVariableSuppressesTerm.txt
@@ -1,0 +1,99 @@
+>>===== MODE =====>>
+citation
+<<===== MODE =====<<
+
+
+>>===== DESCRIPTION =====>>
+<https://github.com/citeproc-py/citeproc-py/issues/204>
+
+CSL 1.0.2 says of `cs:label` that "the term is only rendered if the selected
+variable is non-empty". A label naming a variable the reference does not carry
+must therefore render nothing, rather than leaving the bare term behind: the
+first citation below is `Title` and not `Title, edition, volume, page`.
+
+An empty string counts as empty, so `edition` is still suppressed for the third
+item. The second item carries all three variables, and `page` holds a range, so
+its label is the plural form.
+<<===== DESCRIPTION =====<<
+
+
+>>===== RESULT =====>>
+Title
+Another Title, edition, volume, pages
+Third Title
+<<===== RESULT =====<<
+
+
+>>===== CITATION-ITEMS =====>>
+[
+    [
+        {
+            "id": "ITEM-1"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-2"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-3"
+        }
+    ]
+]
+<<===== CITATION-ITEMS =====<<
+
+
+>>===== CSL =====>>
+<style
+      xmlns="http://purl.org/net/xbiblio/csl"
+      class="in-text"
+      version="1.0">
+  <info>
+    <id />
+    <title />
+    <updated>2026-08-04T00:00:00+00:00</updated>
+  </info>
+  <citation>
+    <layout>
+      <group delimiter=", ">
+        <text variable="title"/>
+        <label variable="edition"/>
+        <label variable="volume"/>
+        <label variable="page"/>
+      </group>
+    </layout>
+  </citation>
+</style>
+<<===== CSL =====<<
+
+
+>>===== INPUT =====>>
+[
+    {
+        "id": "ITEM-1",
+        "type": "book",
+        "title": "Title"
+    },
+    {
+        "id": "ITEM-2",
+        "type": "book",
+        "title": "Another Title",
+        "edition": "2nd",
+        "volume": "3",
+        "page": "12-14"
+    },
+    {
+        "id": "ITEM-3",
+        "type": "book",
+        "title": "Third Title",
+        "edition": ""
+    }
+]
+<<===== INPUT =====<<
+
+
+>>===== VERSION =====>>
+1.0
+<<===== VERSION =====<<


### PR DESCRIPTION
Fixes #204.

CSL 1.0.2 says of `cs:label`: "The term is only rendered if the selected variable is non-empty." `Label.process` looked the term up unconditionally, so a label naming a variable the reference does not carry left the bare term behind — `chicago-shortened-notes-bibliography` (which `renamed-styles.json` now maps `chicago-note-bibliography` onto) cited every item without an edition as `Doe, "A Study of Things", edition.`

## The change

`_variable_is_set` resolves the variable the same way `Text._variable` does: `locator` lives on the citation item, `citation-number` is generated and set for every registered item, and `page-first` derives from `page`. An absent variable and an empty string both count as empty.

The check sits on the branch that reads the variable from the element's own attribute, not below it. `cs:names` passes the variable in, and by that point it has already established that the name variable is set — and what it passes may be the `editortranslator` term, which is not a variable at all. An unconditional check suppresses that label and breaks `name_EditorTranslatorSameWithTerm`; I confirmed that by trying it.

Doing the lookup before the `_is_plural` call also keeps the locator path out of reach when the citation carries no locator.

## Tests

`tests/local/label_EmptyVariableSuppressesTerm.txt` covers the absent variable, the empty string, and the populated case (including plural `pages`). It fails without the fix:

    EXP: Title                                    RES: Title, edition, volume, page
         Another Title, edition, volume, pages         Another Title, edition, volume, pages
         Third Title                                   Third Title, edition, volume, page

Three suite tests pass now and leave `failing_tests.txt`: `bugreports_GreekStyleTwoEditors`, `bugreports_StyleError001`, `bugreports_UndefinedInName3`. No test regressed.
