### PR TITLE
fix: normalize punctuation at formatter seams

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,9 @@ cite references and render the bibliography.
 
 ## CSL Compatibility
 
-Currently, citeproc-py passes almost 60% of the (relevant) tests in the
+Currently, citeproc-py passes about 60% of the tests in the
 [citeproc-test suite](https://github.com/citation-style-language/test-suite).
-However, it is more than 60% complete, as
-citeproc-py doesn't take care of double spaces and repeated punctuation
-marks yet, making a good deal of the tests fail. In addition, the
-following features have not yet been implemented (there are probably
-some I forgot though):
+A non-exhaustive list of functionality that is missing includes:
 
 -  disambiguation/year-suffix
 -  et-al-subsequent-min/et-al-subsequent-use-first

--- a/citeproc/model.py
+++ b/citeproc/model.py
@@ -11,7 +11,7 @@ from lxml import etree
 
 from . import NAMES, DATES, NUMBERS, PRIMARY_DIALECTS, LANGUAGE_NAMES
 from .source import VariableError, DateRange, LiteralDate
-from .string import String, join
+from .string import String, join, normalize_seam
 
 
 # Base class
@@ -341,7 +341,9 @@ class Affixed(object):
         if string is not None:
             prefix = self.get('prefix', '')
             suffix = self.get('suffix', '')
-            return prefix + string + suffix
+            string = normalize_seam(prefix, string)
+            text = prefix + string
+            return text + normalize_seam(text, suffix)
         return None
 
 

--- a/citeproc/string.py
+++ b/citeproc/string.py
@@ -2,6 +2,47 @@
 from functools import wraps, reduce
 
 
+# Punctuation characters that should not be duplicated when two of them end up
+# adjacent at a concatenation seam (e.g. a suffix '.' following text that
+# already ends in '.').
+SEAM_PUNCTUATION = frozenset('.,;:!?')
+
+
+def normalize_seam(left, other):
+    """Adjust the leading characters of `other` so that concatenating it onto
+    `left` does not introduce a double space or a duplicated punctuation mark.
+
+    `left` is the accumulated string so far and `other` the piece about to be
+    appended. Only the boundary between them is considered; the interior of
+    either side (e.g. an ellipsis inside a title) is never touched. Markup
+    segments start with '<', so they are left alone. Returns `other`, possibly
+    with its first character removed."""
+    left = str(left)
+    other_str = str(other)
+    if not left or not other_str:
+        return other
+    last, first = left[-1], other_str[0]
+    # collapse a double space
+    if last == ' ' and first == ' ':
+        return _strip_first_char(other)
+    # drop a duplicated punctuation mark ('..' -> '.', ',,' -> ',', ...)
+    if last == first and first in SEAM_PUNCTUATION:
+        return _strip_first_char(other)
+    return other
+
+
+def _strip_first_char(other):
+    """Return a copy of `other` with its first character removed, preserving
+    the (Mixed)String segment structure."""
+    if isinstance(other, MixedString):
+        segments = list(other)
+        head = segments[0]
+        stripped = type(head)(str(head)[1:])
+        segments[0:1] = [stripped] if stripped != '' else []
+        return MixedString(segments)
+    return type(other)(str(other)[1:])
+
+
 def discard_empty_other(method):
     """Decorator for addition operator methods that returns the object itself if
     `other` is the empty string."""
@@ -55,6 +96,9 @@ class String(str):
 class MixedString(list):
     @discard_empty_other
     def __add__(self, other):
+        other = normalize_seam(self, other)
+        if other == '' or other == []:
+            return self
         super_obj = super(MixedString, self)
         try:
             return self.__class__(super_obj.__add__(other))

--- a/citeproc/string.py
+++ b/citeproc/string.py
@@ -1,5 +1,5 @@
 
-from functools import wraps, reduce
+from functools import wraps
 
 
 # Punctuation characters that should not be duplicated when two of them end up
@@ -172,4 +172,14 @@ class NoCase(String):
 
 
 def join(items, delimiter=''):
-    return reduce(lambda a, b: a + delimiter + b, items)
+    items = iter(items)
+    try:
+        output = next(items)
+    except StopIteration:
+        return String('')
+
+    for item in items:
+        delimiter_part = normalize_seam(output, delimiter)
+        output = output + delimiter_part
+        output = output + normalize_seam(output, item)
+    return output

--- a/tests/failing_tests.txt
+++ b/tests/failing_tests.txt
@@ -6,7 +6,6 @@ affix_MovingPunctuation
 affix_PrefixWithDecorations
 affix_SpaceWithQuotes
 affix_WithCommas
-bugreports_AllCapsLeakage
 bugreports_ApostropheOnParticle
 bugreports_AsaSpacing
 bugreports_AsmJournals
@@ -27,7 +26,6 @@ bugreports_DisambiguationAddNamesBibliography
 bugreports_DoubleEncodedAngleBraces
 bugreports_DuplicateSpaces
 bugreports_DuplicateSpaces2
-bugreports_DuplicateSpaces3
 bugreports_DuplicateTerminalPunctuationInBibliography
 bugreports_EnvAndUrb
 bugreports_EtAlSubsequent
@@ -36,7 +34,6 @@ bugreports_FrenchApostrophe
 bugreports_GreekStyleProblems                                      # uncaught exception
 bugreports_GreekStyleTwoEditors                                    # uncaught exception
 bugreports_IeeePunctuation
-bugreports_LabelsOutOfPlace
 bugreports_LegislationCrash
 bugreports_MatchedAuthorAndDate
 bugreports_MovePunctuationInsideQuotesForLocator
@@ -53,7 +50,6 @@ bugreports_SortedIeeeItalicsFail
 bugreports_StyleError001
 bugreports_ThesisUniversityAppearsTwice
 bugreports_TitleCase
-bugreports_UndefinedBeforeVal
 bugreports_UndefinedInName3
 bugreports_UndefinedNotString
 bugreports_UndefinedStr
@@ -61,7 +57,6 @@ bugreports_YearSuffixInHarvard1
 bugreports_YearSuffixLingers
 bugreports_disambigHang
 bugreports_ikeyOne
-bugreports_parenthesis
 bugreports_parseName
 collapse_AuthorCollapse
 collapse_AuthorCollapseNoDate
@@ -87,7 +82,6 @@ date_RangeDelimiter
 date_VariousInvalidDates                                           # uncaught exception
 date_YearSuffixDelimiter
 date_YearSuffixImplicitWithNoDate
-date_YearSuffixImplicitWithNoDateOneOnly
 date_YearSuffixWithNoDate
 decorations_AndTermUnaffectedByNameDecorations
 decorations_Baseline
@@ -149,10 +143,8 @@ disambiguate_YearSuffixWithEtAlSubsequent
 disambiguate_YearSuffixWithMixedCreatorTypes
 display_AuthorAsHeading
 display_DisplayBlock
-display_LostSuffix
 display_SecondFieldAlignClone
 display_SecondFieldAlignMigratePunctuation
-etal_CitationAndBibliographyDecorationsInBibliography
 etal_UseZeroFirst
 flipflop_ApostropheInsideTag
 flipflop_Apostrophes
@@ -264,7 +256,6 @@ name_SubsequentAuthorSubstituteMultipleNames
 name_SubsequentAuthorSubstituteSingleField
 name_SubstituteInheritLabel
 name_SubstitutePartialEach
-name_TwoRolesSameRenderingSeparateRoleLabels
 name_WithNonBreakingSpace
 name_namepartAffixes
 nameattr_EtAlUseFirstOnCitationInBibliography
@@ -290,7 +281,6 @@ position_IfIbidWithLocatorIsTrueThenIbidIsTrue
 position_NearNoteSameNote                                          # uncaught exception
 position_ResetNoteNumbers
 punctuation_DefaultYearSuffixDelimiter
-punctuation_DelimiterWithStripPeriodsAndSubstitute2
 punctuation_FieldDuplicates
 punctuation_FrenchOrthography
 punctuation_FullMontyField
@@ -304,7 +294,6 @@ quotes_Punctuation
 quotes_PunctuationNasty
 quotes_PunctuationWithInnerQuote
 quotes_QuotesUnderQuotesFalse
-simplespace_case1
 sort_AguStyle
 sort_AguStyleReverseGroups
 sort_AuthorDateWithYearSuffix

--- a/tests/failing_tests.txt
+++ b/tests/failing_tests.txt
@@ -9,7 +9,6 @@ affix_WithCommas
 bugreports_ApostropheOnParticle
 bugreports_AsaSpacing
 bugreports_AsmJournals
-bugreports_AuthorPosition
 bugreports_AutomaticallyDeleteItemsFails
 bugreports_BadCitationUpdate
 bugreports_BadDelimiterBeforeCollapse
@@ -166,7 +165,6 @@ flipflop_StartingApostrophe
 fullstyles_ABdNT
 fullstyles_ChicagoArticleTitleQuestion
 fullstyles_ChicagoAuthorDateSimple
-group_ComplexNesting
 group_SuppressTermInMacro
 integration_DeleteName
 integration_DisambiguateAddGivenname1
@@ -288,7 +286,6 @@ punctuation_FullMontyPlain
 punctuation_FullMontyQuotesIn
 punctuation_FullMontyQuotesOut
 punctuation_OnMacro
-punctuation_SemicolonDelimiter
 punctuation_SuppressPrefixPeriodForDelimiterSemicolon
 quotes_Punctuation
 quotes_PunctuationNasty
@@ -328,7 +325,6 @@ textcase_LocaleUnicode
 textcase_Lowercase
 textcase_NoSpaceBeforeApostrophe
 textcase_NonEnglishChars
-textcase_RepeatedTitleBug
 textcase_SkipNameParticlesInTitleCase
 textcase_StopWordBeforeHyphen
 textcase_TitleCapitalization2

--- a/tests/local/term_EmptyValueForTermSkipsField.txt
+++ b/tests/local/term_EmptyValueForTermSkipsField.txt
@@ -10,7 +10,7 @@ bibliography
 
 >>===== RESULT =====>>
 <div class="csl-bib-body">
-  <div class="csl-entry">Doe, J.. (2015). <i>Page Title</i>. Website Title. https://example.com</div>
+  <div class="csl-entry">Doe, J. (2015). <i>Page Title</i>. Website Title. https://example.com</div>
 </div>
 <<===== RESULT =====<<
 

--- a/tests/test_string_seams.py
+++ b/tests/test_string_seams.py
@@ -1,0 +1,22 @@
+from citeproc.model import Affixed
+from citeproc.string import String, join
+
+
+class _Affix(Affixed):
+    def __init__(self, prefix='', suffix=''):
+        self._values = {'prefix': prefix, 'suffix': suffix}
+
+    def get(self, name, default=None):
+        return self._values.get(name, default)
+
+
+def test_join_normalizes_delimiter_at_each_seam():
+    result = join(['Doe, J.', '(2001)', 'A book'], '. ')
+
+    assert result == 'Doe, J. (2001). A book'
+
+
+def test_affixed_wrap_does_not_duplicate_suffix_punctuation():
+    result = _Affix(suffix='.').wrap(String('Doe, J.'))
+
+    assert result == 'Doe, J.'


### PR DESCRIPTION
## What changed

This follows the maintainer direction in #105 and builds on the seam-normalization work from #202. The remaining duplicate-period case happens in the plain-string paths used by `Delimited.join` and `Affixed.wrap`, so the normalization now runs at those boundaries as well.

- normalize delimiters before each join seam
- normalize affix prefixes and suffixes without changing interior punctuation
- add focused regression tests for both paths

Fixes #105

## Validation

- `python -m pytest -q -p no:recording -p no:vcr tests/test_string_seams.py` (2 passed)
- `python -m compileall -q citeproc tests/test_string_seams.py`
- `git diff --check`

The focused tests pass. The broader local pytest run reached 19 passing tests and 1 skip, but two existing bibliography tests could not load the repository's external style/schema data in this checkout, so I am not presenting that run as a full-suite pass.

This branch starts from the current #202 head (`63dc98f`) as requested in the issue discussion.