### PR TITLE
fix(model): add defensive check in get_locale_option() for Locale roots

### DIFF
--- a/citeproc/model.py
+++ b/citeproc/model.py
@@ -140,7 +140,11 @@ class CitationStylesElement(SomewhatObjectifiedElement):
                 continue
 
     def get_locale_option(self, name):
-        for locale in self.get_root().locales:
+        root = self.get_root()
+        if not hasattr(root, 'locales') or root.locales is None:
+            # root element is Locale, not an iterable of Locales
+            return root.get_option(name)
+        for locale in root.locales:
             try:
                 return locale.get_option(name)
             except IndexError:


### PR DESCRIPTION
## Description

Fix a bug in `get_locale_option()` that causes `TypeError: 'NoneType' object is not iterable` when generating citations with certain locales.

The bug occurs when the method is called on date-part elements whose root is a **Locale** element (from locale files like `locales-cs-CZ.xml`) instead of a **Style** element. Since Locale elements don't have a `.locales` attribute, this causes a TypeError.

### Affected Locales

This bug affects all 10 locales that use ordinal day formatting:
- cs-CZ (Czech)
- da-DK (Danish)
- de-AT, de-CH, de-DE (German - Austria, Switzerland, Germany)
- et-EE (Estonian)
- fi-FI (Finnish)
- nb-NO, nn-NO (Norwegian Bokmål, Nynorsk)
- pt-BR (Portuguese - Brazil)

### Root Cause

The `get_locale_option()` method assumes `self.get_root().locales` is always iterable. However, when called on date-part elements whose root is a **Locale** element (from locale files like `locales-cs-CZ.xml`), `root.locales` is `None`, causing `TypeError: 'NoneType' object is not iterable`.

**Note on bug introduction**:
- The `render_single_date()` method with conditional `context` handling has existed since the initial commit (January 2012)
- No changes were made to `citeproc/model.py` between v0.10.2 and v0.10.4
- The bug exists in all tested versions: v0.8.3, v0.9.3, v0.10.2, v0.10.3, and 

The bug may have only become visible recently due to changes in how locales are loaded (citeproc-py-styles support added in August 2025) or increased usage of locales with ordinal day formatting.

## Backport Request

This bug affects production systems using locales with ordinal day formatting. Requesting backport to Invenio v14 after merge.

## Changes Made

Modified `citeproc/model.py` - `get_locale_option()` method to handle the case where `self.get_root()` returns a Locale element:

```python
def get_locale_option(self, name):
    root = self.get_root()
    if not hasattr(root, 'locales') or root.locales is None:
        # root element is Locale, not an iterable of Locales
        return root.get_option(name)
    for locale in root.locales:
        try:
            return locale.get_option(name)
        except IndexError:
            continue
```

## Testing

Tested with all previously failing locales. 
After the modification, all affected locales generate citations correctly.

```python
from citeproc import Citation, CitationItem, CitationStylesBibliography, CitationStylesStyle, formatter

from citeproc.source.json import CiteProcJSON
from citeproc import __version__

style_path = "/home/ondrej/code/NRP-CZ/datarepo/.venv/lib/python3.14/site-packages/citeproc_styles/styles/ieee.csl"

json_data = {
    'id': 'test',
    'type': 'article',
    'title': 'Test Record',
    'author': [{'family': 'Doe', 'given': 'John'}],
    'issued': {'date-parts': [['1999', '01', '01']]},
    'publisher': 'Test Publisher'
}

# Test all locales with ordinal day formatting
locales_to_test = ["cs-CZ", "da-DK", "de-AT", "de-CH", "de-DE", "et-EE", "fi-FI", "nb-NO", "nn-NO", "pt-BR"]

print(f"citeproc version {__version__}:\n")
for locale in locales_to_test:
    try:
        source = CiteProcJSON([json_data])
        citation_style = CitationStylesStyle(validate=False, style=style_path, locale=locale)
        bib = CitationStylesBibliography(citation_style, source, formatter.plain)
        citation = Citation([CitationItem("test")])
        bib.register(citation)
        citation_raw = str(bib.bibliography()[0])
        print(f"{locale}: OK - {citation_raw[:70]}...")
    except Exception as e:
        print(f"{locale}: ERROR - {e}")
```
Output without the modification:
```terminaloutput
citeproc version 0.10.4:
cs-CZ: ERROR - 'NoneType' object is not iterable
da-DK: ERROR - 'NoneType' object is not iterable
de-AT: ERROR - 'NoneType' object is not iterable
de-CH: ERROR - 'NoneType' object is not iterable
de-DE: ERROR - 'NoneType' object is not iterable
et-EE: ERROR - 'NoneType' object is not iterable
fi-FI: ERROR - 'NoneType' object is not iterable
nb-NO: ERROR - 'NoneType' object is not iterable
nn-NO: ERROR - 'NoneType' object is not iterable
pt-BR: ERROR - 'NoneType' object is not iterable
```
Output with the modification:
```terminaloutput
citeproc version 0.10.4+1.g3ecf3ee.dirty:
cs-CZ: OK - [1]J. Doe, „Test Record“, 1. leden 1999, Test Publisher....
da-DK: OK - [1]J. Doe, “Test Record”, 1. januar 1999, Test Publisher....
de-AT: OK - [1]J. Doe, „Test Record“, 1. Jänner 1999, Test Publisher....
de-CH: OK - [1]J. Doe, «Test Record», 1. Januar 1999, Test Publisher....
de-DE: OK - [1]J. Doe, „Test Record“, 1. Januar 1999, Test Publisher....
et-EE: OK - [1]J. Doe, „Test Record“, 1. jaanuar 1999, Test Publisher....
fi-FI: OK - [1]J. Doe, ”Test Record”, 1. tammikuuta 1999, Test Publisher....
nb-NO: OK - [1]J. Doe, «Test Record», 1. januar 1999, Test Publisher....
nn-NO: OK - [1]J. Doe, «Test Record», 1. januar 1999, Test Publisher....
pt-BR: OK - [1]J. Doe, “Test Record”, 1ª de janeiro de 1999, Test Publisher....
```